### PR TITLE
Make Jisho command index go through results, not meanings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ That's it! :)
 
 A command for testing which prints out the requesting user's name.
 
-### `!j <term>`
+### `!j <term> [<result_number>]`
 
 Returns the jisho.org entires for `<term>`. Example: `!j 関係`.
 This is limited to three meanings.
 
-### `!jfrom <result_number> <term>`
-
-Returns the jisho.org entires for `<term>`, but starting from result number `result_number`.
-This is useful for looking at meanings of terms with many meanings. Example: `!j 5 関係`.
+This command can also take a number at the end. Example: `!j 関係 2`.
+This would return the second result for “関係”.
 
 ### `!add_tag <tag_name> <tag_response>`
 

--- a/bot_tools.py
+++ b/bot_tools.py
@@ -66,7 +66,4 @@ def jisho(keyword):
         "http://jisho.org/api/v1/search/words?keyword={}".format(keyword)
     ).text)["data"]
 
-    if len(results) > 0:
-        return results[0]
-    else:
-        return None
+    return results


### PR DESCRIPTION
Doing `!j 関係 2` now returns the second _result_ of 関係. The meanings are shown as before, a maximum of three per term.

Also, fixed bug where looking up words without kanji would fail.